### PR TITLE
bump version 0.4.1

### DIFF
--- a/README.md
+++ b/README.md
@@ -7,7 +7,7 @@ A Clojure library designed to use [Netflix/archaius](https://github.com/Netflix/
 Leiningen dependency:
 
 ```clj
-[clj-archaius "0.2.0]
+[cn.leancloud/clj-archaius "0.4.1"]
 ```
 
 Require clj-archaius in your namespace:

--- a/project.clj
+++ b/project.clj
@@ -1,8 +1,8 @@
-(defproject cn.leancloud/clj-archaius "0.4.0"
+(defproject cn.leancloud/clj-archaius "0.4.1"
   :description "A Clojure library designed to use Netflix/archaius for configuration management."
   :url "https://github.com/leancloud/clj-archaius"
   :license {:name "Eclipse Public License"
             :url "http://www.eclipse.org/legal/epl-v10.html"}
   :dependencies [[org.clojure/clojure "1.8.0"]
-                 [cn.leancloud/archaius-core "0.7.8-a"]]
+                 [cn.leancloud/archaius-core "0.7.8-b"]]
   :profiles {:dev {:resource-paths ["dev"]}})


### PR DESCRIPTION
Upgrade archiaus-core handle blank config url and bump version to 0.4.1